### PR TITLE
Updated module for new React version 15.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+*.un~

--- a/package.json
+++ b/package.json
@@ -20,22 +20,22 @@
   ],
   "author": "atabel",
   "license": "MIT",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/atabel/tape-jsx-equals.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atabel/tape-jsx-equals.git"
   },
   "homepage": "https://github.com/atabel/tape-jsx-equals",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "eslint": "^1.7.1",
-    "eslint-plugin-react": "^3.6.2",
-    "extend-tape": "^1.0.1",
+    "babel": "^5.8.38",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.16.1",
+    "extend-tape": "^1.2.0",
     "faucet": "0.0.1",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "tape": "^4.2.1"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "tape": "^4.6.3"
   },
   "dependencies": {
-    "react-element-to-jsx-string": "^2.0.4"
+    "react-element-to-jsx-string": "^6.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tape-jsx-equals",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "tape assertion to compare react components",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extend-tape": "^1.2.0",
     "faucet": "0.0.1",
     "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "tape": "^4.6.3"
   },
   "dependencies": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { createRenderer } from 'react-dom/test-utils';
+import ReactShallowRenderer from 'react-test-renderer/shallow';
 import tape from 'tape';
 import addAssertions from 'extend-tape';
 import jsxEquals from '..';
 
 const test = addAssertions(tape, {jsxEquals});
-const renderer = createRenderer();
+const renderer = new ReactShallowRenderer();
 
 const MyComponent = function ({color}) {
     const className = `box color-${color}`;

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createRenderer} from 'react-addons-test-utils';
+import { createRenderer } from 'react-dom/test-utils';
 import tape from 'tape';
 import addAssertions from 'extend-tape';
 import jsxEquals from '..';


### PR DESCRIPTION
The current lib. is throwing the error shown below because an old version of [react-element-to-jsx-string](https://github.com/algolia/react-element-to-jsx-string) is being used. Exactly the version is `2.0.4`. The current version is `6.4.0`.

```shell
Error: Cannot find module 'react-addons-test-utils'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/enric/Workspace/learning/tape/node_modules/react-element-to-jsx-string/index-dist.js:18:29)
    at Module._compile (module.js:571:32)
    at Module._extensions..js (module.js:580:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/enric/Workspace/learning/tape/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
not ok 1 no plan found
not ok 2 no assertions found
```
Also, I've modified the [react-addons-test-utils](https://www.npmjs.com/package/react-addons-test-utils) because has been deprecated from React v15.5.0. Now those utils are in [react-dom](https://www.npmjs.com/package/react-dom) module. The test is passing properly.